### PR TITLE
Check if filecontent in js is a string for base64 decoding

### DIFF
--- a/Blazor.DownloadFileFast/JavaScript/download.js
+++ b/Blazor.DownloadFileFast/JavaScript/download.js
@@ -1,6 +1,6 @@
 ﻿function BlazorDownloadFile(filename, contentType, content) {
-    // Blazor marshall byte[] to a base64 string, so we first need to convert the string (content) to a Uint8Array to create the File
-    const data = base64DecToArr(content);
+    // In < .net6.0 Blazor marshall byte[] to a base64 string, so we first need to convert the string (content) to a Uint8Array to create the File
+    const data = typeof(content) === "string" ? base64DecToArr(content) : content;
 
     // Create the URL
     const file = new File([data], filename, { type: contentType });


### PR DESCRIPTION
Blazor has a breaking change in .net6 and does not convert the byte array into base64 anymore. 
https://docs.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/6.0/byte-array-interop

This change checks the submitted type of the content parameter in javascript.  In .net below version 6 the injected base64 string will be decoded.